### PR TITLE
add scrolling view for example of hint_page second screen.

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx1024m

--- a/lib/meta/views/hint_page.dart
+++ b/lib/meta/views/hint_page.dart
@@ -99,7 +99,7 @@ class _HintPageState extends State<HintPage> {
 
   Widget secondPage() {
     return SingleChildScrollView(
-      physics: NeverScrollableScrollPhysics(),
+      physics: BouncingScrollPhysics(),
       child: Padding(
         padding: EdgeInsets.all(15),
         child: Column(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -67,6 +67,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
@@ -80,7 +87,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -120,7 +127,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,7 +141,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -169,14 +176,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=1.16.0"


### PR DESCRIPTION
The issue of not visible is solved by adding scrollable view to popup or hint screen.
![image](https://user-images.githubusercontent.com/96297602/196778934-998ebced-23a3-4322-9be1-f5be7e0d8036.png)
![image](https://user-images.githubusercontent.com/96297602/196778713-66a609e1-69f5-4ebc-a12c-435252cc0237.png)
